### PR TITLE
Fix on_boot multi-file merging issue

### DIFF
--- a/common/add-co.yaml
+++ b/common/add-co.yaml
@@ -11,19 +11,25 @@ logger:
     ads1115.sensor: ERROR
 
 esphome:
+  # Use unique priority values for each on_boot 
+  # Prevents multi-file config merging from dropping older priorities
   on_boot:
     - priority: 100.0
       then:
         - lambda: |-
             // don't wait for update rate, force an immediate temperature update
             id(co_temperature).update();
-        - logger.log: "on_boot priority 100 fired (CO sensor)"
+        - logger.log:
+            level: VERBOSE
+            format: "on_boot priority 100.0 fired (add-co.yaml)"
     - priority: 600.0
       then:
         - lambda: |-
             // Let other parts of config know there is a CO sensor
             id(co_available_var) = true;
-        - logger.log: "on_boot priority 600 fired (CO sensor)"
+        - logger.log:
+            level: VERBOSE
+            format: "on_boot priority 600.0 fired (add-co.yaml)"
 
 api:
   on_client_connected:

--- a/common/common.yaml
+++ b/common/common.yaml
@@ -16,16 +16,22 @@ esphome:
   project:
     version: ${config_version}
     name: Mike Lawrence.Indoor Multi-Sensor Rev-B
+  # Use unique priority values for each on_boot 
+  # Prevents multi-file config merging from dropping older priorities
   on_boot:
     - priority: 500.0
       then:
         - script.execute: update_status_led
-        - logger.log: "on_boot priority 500 fired (Common)"
+        - logger.log:
+            level: VERBOSE
+            format: "on_boot priority 500 fired (common.yaml)"
     - priority: 600.0
       then:
         - light.turn_off:
             id: led_status
-        - logger.log: "on_boot priority 600 fired (Common)"
+        - logger.log:
+            level: VERBOSE
+            format: "on_boot priority 600 fired (common.yaml)"
 
 # ESP32-S3-WROOM-2-N32R16V
 # Even though there is 32MB of flash, OTA updates with that size are not reliable

--- a/common/feat-auto-vent.yaml
+++ b/common/feat-auto-vent.yaml
@@ -10,17 +10,23 @@ substitutions:
   vent_co2_off_trigger: "1400"
 
 esphome:
+  # Use unique priority values for each on_boot 
+  # Prevents multi-file config merging from dropping older priorities
   on_boot:
-    then:
-      - binary_sensor.template.publish:
-          id: vent_auto_hum
-          state: false
-      - binary_sensor.template.publish:
-          id: vent_auto_co2
-          state: false
-      - binary_sensor.template.publish:
-          id: vent_manual
-          state: false
+    - priority: 601.0
+      then:
+        - binary_sensor.template.publish:
+            id: vent_auto_hum
+            state: false
+        - binary_sensor.template.publish:
+            id: vent_auto_co2
+            state: false
+        - binary_sensor.template.publish:
+            id: vent_manual
+            state: false
+        - logger.log:
+            level: VERBOSE
+            format: "on_boot priority 601.0 fired (feat-auto-vent.yaml)"
 
 interval:
   - interval: 10s

--- a/common/pkga-sen6x.yaml
+++ b/common/pkga-sen6x.yaml
@@ -19,15 +19,19 @@ external_components:
     components: [sen6x]
 
 esphome:
+  # Use unique priority values for each on_boot 
+  # Prevents multi-file config merging from dropping older priorities
   on_boot:
-    - priority: 600.0
+    - priority: 602.0
       then:
         - lambda: |-
             // Let other parts of config know there is a CO₂ sensor
             id(co2_available_var) = true;
             // Let other parts of config know there is a Particulate Matter sensor
             id(pm25_available_var) = true;
-        - logger.log: "on_boot priority 600 fired (SEN6X sensor)"
+        - logger.log:
+            level: VERBOSE
+            format: "on_boot priority 602.0 fired (pkga-sen6x.yaml)"
 
 api:
   on_client_connected:

--- a/common/pkgb-scd4x.yaml
+++ b/common/pkgb-scd4x.yaml
@@ -8,11 +8,14 @@ substitutions:
 
 esphome:
   on_boot:
-    priority: 800.0
-    then:
-      - lambda: |-
-          // Let other parts of config know there is a CO₂ sensor
-          id(co2_available_var) = true;
+    - priority: 800.0
+      then:
+        - lambda: |-
+            // Let other parts of config know there is a CO₂ sensor
+            id(co2_available_var) = true;
+        - logger.log:
+            level: VERBOSE
+            format: "on_boot priority 800.0 fired (pkgb-scd4x.yaml)"
 
 api:
   on_client_connected:

--- a/common/radar-ld2450.yaml
+++ b/common/radar-ld2450.yaml
@@ -622,8 +622,8 @@ text_sensor:
     ld2450_id: ld2450_radar
     version:
       name: LD2450 Firmware
+      entity_category: diagnostic
   - platform: template
     name: "Radar Included"
-    id: radar_included
-    entity_category: config
+    entity_category: diagnostic
     update_interval: never


### PR DESCRIPTION
Make on_boot priority unique across configuration files. This prevents the merge from overwriting previous priorities of the same value.
Change to more appropriate diagnostic category for certain text_sensors.