### PR TITLE
on_boot changes

### DIFF
--- a/common/add-co.yaml
+++ b/common/add-co.yaml
@@ -5,18 +5,22 @@ logger:
 
 esphome:
   on_boot:
-    - priority: 100.0
+    - priority: 101.0
       then:
         - lambda: |-
             // don't wait for update rate, force an immediate temperature update
             id(co_temperature).update();
-        - logger.log: "on_boot priority 100 fired (CO sensor)"
-    - priority: 600.0
+        - logger.log:
+          format: "on_boot priority 101 fired (CO sensor)"
+          level: VERBOSE
+    - priority: 601.0
       then:
         - lambda: |-
             // Let other parts of config know there is a CO sensor
             id(co_available_var) = true;
-        - logger.log: "on_boot priority 600 fired (CO sensor)"
+        - logger.log:
+          format: "on_boot priority 601 fired (CO sensor)"
+          level: VERBOSE
 
 globals:
   - id: co_temp_calibration

--- a/common/add-co.yaml
+++ b/common/add-co.yaml
@@ -11,16 +11,16 @@ esphome:
             // don't wait for update rate, force an immediate temperature update
             id(co_temperature).update();
         - logger.log:
-          format: "on_boot priority 101 fired (CO sensor)"
-          level: VERBOSE
+            format: "on_boot priority 101 fired (CO sensor)"
+            level: VERBOSE
     - priority: 601.0
       then:
         - lambda: |-
             // Let other parts of config know there is a CO sensor
             id(co_available_var) = true;
         - logger.log:
-          format: "on_boot priority 601 fired (CO sensor)"
-          level: VERBOSE
+            format: "on_boot priority 601 fired (CO sensor)"
+            level: VERBOSE
 
 globals:
   - id: co_temp_calibration

--- a/common/common.yaml
+++ b/common/common.yaml
@@ -19,17 +19,26 @@ esphome:
     - priority: 500.0
       then:
         - script.execute: update_status_led
-        - logger.log: "on_boot priority 500 fired (Common)"
+        - logger.log:
+          format: "on_boot priority 500 fired (Common)"
+          level: VERBOSE
     - priority: -100.0
       then:
         - script.execute: announce_operational
-        - logger.log: "on_boot priority -100 fired (Common)"
+        - globals.set:
+          id: boot_completed
+          value: 'true'
+        - logger.log:
+          format: "on_boot priority -100 fired (Common)"
+          level: VERBOSE
   on_shutdown:
     - priority: 600.0
       then:
         - light.turn_off:
             id: led_status
-        - logger.log: "on_shutdown priority 600 fired (Common)"
+        - logger.log:
+          format: "on_shutdown priority 600 fired (Common)"
+          level: VERBOSE
 
 # ESP32-S3-WROOM-2-N32R16V
 # Even though there is 32MB of flash, OTA updates with that size are not reliable
@@ -47,6 +56,9 @@ psram:
   speed: 80MHz
 
 globals:
+  - id: boot_completed
+    type: bool
+    initial_value: "false"
   - id: silence_alarms_var
     type: bool
     initial_value: "false"

--- a/common/common.yaml
+++ b/common/common.yaml
@@ -26,8 +26,8 @@ esphome:
       then:
         - script.execute: announce_operational
         - globals.set:
-          id: boot_completed
-          value: 'true'
+            id: boot_completed
+            value: 'true'
         - logger.log:
             format: "on_boot priority -100 fired (Common)"
             level: VERBOSE

--- a/common/common.yaml
+++ b/common/common.yaml
@@ -20,8 +20,8 @@ esphome:
       then:
         - script.execute: update_status_led
         - logger.log:
-          format: "on_boot priority 500 fired (Common)"
-          level: VERBOSE
+            format: "on_boot priority 500 fired (Common)"
+            level: VERBOSE
     - priority: -100.0
       then:
         - script.execute: announce_operational
@@ -29,16 +29,16 @@ esphome:
           id: boot_completed
           value: 'true'
         - logger.log:
-          format: "on_boot priority -100 fired (Common)"
-          level: VERBOSE
+            format: "on_boot priority -100 fired (Common)"
+            level: VERBOSE
   on_shutdown:
     - priority: 600.0
       then:
         - light.turn_off:
             id: led_status
         - logger.log:
-          format: "on_shutdown priority 600 fired (Common)"
-          level: VERBOSE
+            format: "on_shutdown priority 600 fired (Common)"
+            level: VERBOSE
 
 # ESP32-S3-WROOM-2-N32R16V
 # Even though there is 32MB of flash, OTA updates with that size are not reliable

--- a/common/feat-auto-vent.yaml
+++ b/common/feat-auto-vent.yaml
@@ -9,7 +9,7 @@ substitutions:
 
 esphome:
   on_boot:
-    - priority: -101.0
+    - priority: -102.0
       then:
         - binary_sensor.template.publish:
             id: vent_auto_hum
@@ -20,7 +20,9 @@ esphome:
         - binary_sensor.template.publish:
             id: vent_manual
             state: false
-        - logger.log: "on_boot priority -101 fired (Auto Vent)"
+        - logger.log:
+          format: "on_boot priority -102 fired (Auto Vent)"
+          level: VERBOSE
 
 interval:
   - interval: 10s

--- a/common/feat-auto-vent.yaml
+++ b/common/feat-auto-vent.yaml
@@ -21,8 +21,8 @@ esphome:
             id: vent_manual
             state: false
         - logger.log:
-          format: "on_boot priority -102 fired (Auto Vent)"
-          level: VERBOSE
+            format: "on_boot priority -102 fired (Auto Vent)"
+            level: VERBOSE
 
 interval:
   - interval: 10s

--- a/common/feat-smoke-alarm.yaml
+++ b/common/feat-smoke-alarm.yaml
@@ -4,9 +4,12 @@
 #         !!!Use at your own risk!!!
 interval:
   - interval: 10s
-    startup_delay: 10s
     then:
-      - script.execute: smoke_alarm_state_machine
+      if:
+        condition:
+          lambda: !lambda return id(boot_completed);
+        then:
+          script.execute: smoke_alarm_state_machine
 
 media_player:
   - platform: speaker

--- a/common/pkga-sen6x.yaml
+++ b/common/pkga-sen6x.yaml
@@ -19,14 +19,16 @@ external_components:
 
 esphome:
   on_boot:
-    - priority: 601.0
+    - priority: 603.0
       then:
         - lambda: |-
             // Let other parts of config know there is a CO₂ sensor
             id(co2_available_var) = true;
             // Let other parts of config know there is a Particulate Matter sensor
             id(pm25_available_var) = true;
-        - logger.log: "on_boot priority 600 fired (SEN6X sensor)"
+        - logger.log:
+          format: "on_boot priority 603 fired (SEN6X sensor)"
+          level: VERBOSE
 
 interval:
   - interval: 7d

--- a/common/pkga-sen6x.yaml
+++ b/common/pkga-sen6x.yaml
@@ -27,8 +27,8 @@ esphome:
             // Let other parts of config know there is a Particulate Matter sensor
             id(pm25_available_var) = true;
         - logger.log:
-          format: "on_boot priority 603 fired (SEN6X sensor)"
-          level: VERBOSE
+            format: "on_boot priority 603 fired (SEN6X sensor)"
+            level: VERBOSE
 
 interval:
   - interval: 7d


### PR DESCRIPTION
Priorities in different files use different offsets. Makes things little clearer. Add boot_completed global variable. Hold off smoke detector script intial launch until after boot_completed.