### PR TITLE
CI ignore main pushes/merges and allow Workflow Dispach

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   push:
+    branches-ignore:
+      - main
     paths:
       - "**.yaml"
       - ".github/workflows/ci.yml"
@@ -12,6 +14,7 @@ on:
   schedule:
     # Weekly on Sunday at midnight
     - cron: "0 0 * * 0"
+  workflow_dispatch:
 
 concurrency:
   group: "Only one at a time"


### PR DESCRIPTION
Pushes/merges onto main will not launch CI workflow. The expectation is CI is run with Pull Requests and vetted before merging into main.
Workflow Display is now allowed just in case.