### PR TITLE
Add substitutions

### DIFF
--- a/common/common.yaml
+++ b/common/common.yaml
@@ -8,7 +8,6 @@ substitutions:
   status_night_brightness: "0.15"
   status_daytime_lux: "10.0"
   status_nighttime_lux: "3.0"
-  presence_ha_entity: "binary_sensor.unknown_room_occupancy"
 
 esphome:
   name_add_mac_suffix: false

--- a/rev-b-pkg-a-c4001-esp32-s3.yaml
+++ b/rev-b-pkg-a-c4001-esp32-s3.yaml
@@ -3,13 +3,23 @@ substitutions:
   friendly_name: "Multi-Sensor Pkg-A C4001"
 
   # Settings
+  # Voice name allows you to change the voice of spoken announcements to fit your preferences.
+  #   For a list of voice names see https://github.com/mikelawrence/esphome-indoor-multi-sensor-sounds/#available-voices
+  voice_name: "lily-wolff-female"
   # Status LED Configuration
   status_nightlight_brightness: "1.0"
   status_day_brightness: "0.5"
   status_night_brightness: "0.20"
   status_daytime_lux: "12.0"
   status_nighttime_lux: "7.0"
-  presence_ha_entity: "binary_sensor.unknown_room_occupancy"
+  # Automatically controlled Vent
+  vent_use_humidity: "true"
+  vent_use_co2: "true"
+  vent_min_on_time: "15"
+  vent_hum_on_trigger: "10.0"
+  vent_hum_off_trigger: "2.5"
+  vent_co2_on_trigger: "1100"
+  vent_co2_off_trigger: "900"
 
 packages:
   remote:

--- a/rev-b-pkg-a-ld2410-esp32-s3.yaml
+++ b/rev-b-pkg-a-ld2410-esp32-s3.yaml
@@ -3,13 +3,23 @@ substitutions:
   friendly_name: "Multi-Sensor Pkg-A LD2410"
 
   # Settings
+  # Voice name allows you to change the voice of spoken announcements to fit your preferences.
+  #   For a list of voice names see https://github.com/mikelawrence/esphome-indoor-multi-sensor-sounds/#available-voices
+  voice_name: "lily-wolff-female"
   # Status LED Configuration
   status_nightlight_brightness: "1.0"
   status_day_brightness: "0.5"
   status_night_brightness: "0.20"
   status_daytime_lux: "12.0"
   status_nighttime_lux: "7.0"
-  presence_ha_entity: "binary_sensor.unknown_room_occupancy"
+  # Automatically controlled Vent
+  vent_use_humidity: "true"
+  vent_use_co2: "true"
+  vent_min_on_time: "15"
+  vent_hum_on_trigger: "10.0"
+  vent_hum_off_trigger: "2.5"
+  vent_co2_on_trigger: "1100"
+  vent_co2_off_trigger: "900"
 
 packages:
   remote:

--- a/rev-b-pkg-a-ld2410s-esp32-s3.yaml
+++ b/rev-b-pkg-a-ld2410s-esp32-s3.yaml
@@ -3,13 +3,23 @@ substitutions:
   friendly_name: "Multi-Sensor Pkg-A LD2410S"
 
   # Settings
+  # Voice name allows you to change the voice of spoken announcements to fit your preferences.
+  #   For a list of voice names see https://github.com/mikelawrence/esphome-indoor-multi-sensor-sounds/#available-voices
+  voice_name: "lily-wolff-female"
   # Status LED Configuration
   status_nightlight_brightness: "1.0"
   status_day_brightness: "0.5"
   status_night_brightness: "0.20"
   status_daytime_lux: "12.0"
   status_nighttime_lux: "7.0"
-  presence_ha_entity: "binary_sensor.unknown_room_occupancy"
+  # Automatically controlled Vent
+  vent_use_humidity: "true"
+  vent_use_co2: "true"
+  vent_min_on_time: "15"
+  vent_hum_on_trigger: "10.0"
+  vent_hum_off_trigger: "2.5"
+  vent_co2_on_trigger: "1100"
+  vent_co2_off_trigger: "900"
 
 packages:
   remote:

--- a/rev-b-pkg-a-ld2450-esp32-s3.yaml
+++ b/rev-b-pkg-a-ld2450-esp32-s3.yaml
@@ -3,13 +3,23 @@ substitutions:
   friendly_name: "Multi-Sensor Pkg-A LD2450"
 
   # Settings
+  # Voice name allows you to change the voice of spoken announcements to fit your preferences.
+  #   For a list of voice names see https://github.com/mikelawrence/esphome-indoor-multi-sensor-sounds/#available-voices
+  voice_name: "lily-wolff-female"
   # Status LED Configuration
   status_nightlight_brightness: "1.0"
   status_day_brightness: "0.5"
   status_night_brightness: "0.20"
   status_daytime_lux: "12.0"
   status_nighttime_lux: "7.0"
-  presence_ha_entity: "binary_sensor.unknown_room_occupancy"
+  # Automatically controlled Vent
+  vent_use_humidity: "true"
+  vent_use_co2: "true"
+  vent_min_on_time: "15"
+  vent_hum_on_trigger: "10.0"
+  vent_hum_off_trigger: "2.5"
+  vent_co2_on_trigger: "1100"
+  vent_co2_off_trigger: "900"
 
 packages:
   remote:

--- a/rev-b-pkg-b-c4001-esp32-s3.yaml
+++ b/rev-b-pkg-b-c4001-esp32-s3.yaml
@@ -3,13 +3,23 @@ substitutions:
   friendly_name: "Multi-Sensor Pkg-B C4001"
 
   # Settings
+  # Voice name allows you to change the voice of spoken announcements to fit your preferences.
+  #   For a list of voice names see https://github.com/mikelawrence/esphome-indoor-multi-sensor-sounds/#available-voices
+  voice_name: "lily-wolff-female"
   # Status LED Configuration
   status_nightlight_brightness: "1.0"
   status_day_brightness: "0.5"
   status_night_brightness: "0.20"
   status_daytime_lux: "12.0"
   status_nighttime_lux: "7.0"
-  presence_ha_entity: "binary_sensor.unknown_room_occupancy"
+  # Automatically controlled Vent
+  vent_use_humidity: "true"
+  vent_use_co2: "true"
+  vent_min_on_time: "15"
+  vent_hum_on_trigger: "10.0"
+  vent_hum_off_trigger: "2.5"
+  vent_co2_on_trigger: "1100"
+  vent_co2_off_trigger: "900"
 
 packages:
   remote:

--- a/rev-b-pkg-b-ld2410-esp32-s3.yaml
+++ b/rev-b-pkg-b-ld2410-esp32-s3.yaml
@@ -3,13 +3,23 @@ substitutions:
   friendly_name: "Multi-Sensor Pkg-B LD2410"
 
   # Settings
+  # Voice name allows you to change the voice of spoken announcements to fit your preferences.
+  #   For a list of voice names see https://github.com/mikelawrence/esphome-indoor-multi-sensor-sounds/#available-voices
+  voice_name: "lily-wolff-female"
   # Status LED Configuration
   status_nightlight_brightness: "1.0"
   status_day_brightness: "0.5"
   status_night_brightness: "0.20"
   status_daytime_lux: "12.0"
   status_nighttime_lux: "7.0"
-  presence_ha_entity: "binary_sensor.unknown_room_occupancy"
+  # Automatically controlled Vent
+  vent_use_humidity: "true"
+  vent_use_co2: "true"
+  vent_min_on_time: "15"
+  vent_hum_on_trigger: "10.0"
+  vent_hum_off_trigger: "2.5"
+  vent_co2_on_trigger: "1100"
+  vent_co2_off_trigger: "900"
 
 packages:
   remote:

--- a/rev-b-pkg-b-ld2410s-esp32-s3.yaml
+++ b/rev-b-pkg-b-ld2410s-esp32-s3.yaml
@@ -3,13 +3,23 @@ substitutions:
   friendly_name: "Multi-Sensor Pkg-B LD2410S"
 
   # Settings
+  # Voice name allows you to change the voice of spoken announcements to fit your preferences.
+  #   For a list of voice names see https://github.com/mikelawrence/esphome-indoor-multi-sensor-sounds/#available-voices
+  voice_name: "lily-wolff-female"
   # Status LED Configuration
   status_nightlight_brightness: "1.0"
   status_day_brightness: "0.5"
   status_night_brightness: "0.20"
   status_daytime_lux: "12.0"
   status_nighttime_lux: "7.0"
-  presence_ha_entity: "binary_sensor.unknown_room_occupancy"
+  # Automatically controlled Vent
+  vent_use_humidity: "true"
+  vent_use_co2: "true"
+  vent_min_on_time: "15"
+  vent_hum_on_trigger: "10.0"
+  vent_hum_off_trigger: "2.5"
+  vent_co2_on_trigger: "1100"
+  vent_co2_off_trigger: "900"
 
 packages:
   remote:

--- a/rev-b-pkg-b-ld2450-esp32-s3.yaml
+++ b/rev-b-pkg-b-ld2450-esp32-s3.yaml
@@ -3,13 +3,23 @@ substitutions:
   friendly_name: "Multi-Sensor Pkg-B LD2450"
 
   # Settings
+  # Voice name allows you to change the voice of spoken announcements to fit your preferences.
+  #   For a list of voice names see https://github.com/mikelawrence/esphome-indoor-multi-sensor-sounds/#available-voices
+  voice_name: "lily-wolff-female"
   # Status LED Configuration
   status_nightlight_brightness: "1.0"
   status_day_brightness: "0.5"
   status_night_brightness: "0.20"
   status_daytime_lux: "12.0"
   status_nighttime_lux: "7.0"
-  presence_ha_entity: "binary_sensor.unknown_room_occupancy"
+  # Automatically controlled Vent
+  vent_use_humidity: "true"
+  vent_use_co2: "true"
+  vent_min_on_time: "15"
+  vent_hum_on_trigger: "10.0"
+  vent_hum_off_trigger: "2.5"
+  vent_co2_on_trigger: "1100"
+  vent_co2_off_trigger: "900"
 
 packages:
   remote:

--- a/static/configuration.md
+++ b/static/configuration.md
@@ -1,0 +1,250 @@
+---
+layout: default
+title: ESPHome Indoor Multi-Sensor
+description: Configuration in ESPHome after taking control
+---
+
+## Configuration
+
+Once you take control in ESPHome, there are two sections you need to configure, `substitutions:` and `packages:`. In the `substitutions:` section you will find settings for many of the available sensors.
+You only need to declare substitutions if you need a value other than default.
+
+> With yaml all substitutions are strings and should be in `'single quotes'` or  
+> `"double quotes"` even if the value is a float or a boolean value.
+
+```yaml
+substitutions:
+  name: "sensor-rev-b-pkg-a"
+  friendly_name: "Indoor Multi-Sensor Rev-B Sens-Pkg-A C4001"
+
+  # Settings
+  # Voice name allows you to change the voice of spoken announcements to fit your preferences.
+  #   For a list of voice names see https://github.com/mikelawrence/esphome-indoor-multi-sensor-sounds/#available-voices
+  voice_name: "lily-wolff-female"
+  # Status LED Configuration
+  status_nightlight_brightness: "1.0"
+  status_day_brightness: "0.5"
+  status_night_brightness: "0.20"
+  status_daytime_lux: "12.0"
+  status_nighttime_lux: "7.0"
+  # Automatically controlled Vent
+  vent_use_humidity: "true"
+  vent_use_co2: "true"
+  vent_min_on_time: "15"
+  vent_hum_on_trigger: "10.0"
+  vent_hum_off_trigger: "2.5"
+  vent_co2_on_trigger: "1100"
+  vent_co2_off_trigger: "900"
+```
+
+The `packages:` section will allow you to disable sensors by commenting out it's included package.
+
+```yaml
+packages:
+  remote:
+    url: https://github.com/mikelawrence/esphome-indoor-multi-sensor-config
+    refresh: 1min
+    ref: main
+    files:
+      # Main Config Files for Sensor Package-A and C4001 Radar
+      - common/common.yaml
+      - common/pkga-sen6x.yaml
+      - common/radar-ld2410s.yaml
+
+      # ADDITIONAL SENSORS
+      # Carbon Dioxide (CO) - Figaro TGS5141 sensor
+      - common/add-co.yaml
+      # Energy Usage Rev-B - INA2XX sensor to measure Voltage, Power and Energy Usage, Rev B only
+      - common/add-ina2xx-rev-b.yaml
+      # Energy Usage - INA2XX sensor to measure Voltage, Power and Energy Usage
+      - common/add-ina2xx.yaml
+      # Light Level - TSL2591 sensor
+      - common/add-tsl2591.yaml
+      # Barometric Pressure - BMP581 sensor
+      - common/add-bmp581.yaml
+      # Microphone - Adds Sound Level meter
+      - common/add-microphone.yaml
+
+      # FEATURES
+      # Automatic Vent - Use humidity and CO₂ to control a bathroom vent
+      # - common/feat-auto-vent.yaml
+      # Smoke Alarm - Use PM and CO₂ for smoke alarm functionality
+      # - common/feat-smoke-alarm.yaml
+```
+
+The Main Config Files vary based on Sensor Package and Radar. Only these combinations of Main Config Files will work.
+
+```yaml
+      # Main Config Files for Sensor Package-A and C4001 Radar
+      - common/common.yaml
+      - common/pkga-sen6x.yaml
+      - common/radar-c4001.yaml
+
+      # Main Config Files for Sensor Package-A and LD2410 Radar
+      - common/common.yaml
+      - common/pkga-sen6x.yaml
+      - common/radar-ld2410.yaml
+
+      # Main Config Files for Sensor Package-A and LD2450 Radar
+      - common/common.yaml
+      - common/pkga-sen6x.yaml
+      - common/radar-ld2450.yaml
+
+      # Main Config Files for Sensor Package-A and LD2410S Radar, Warning: Rev-B only!
+      - common/common.yaml
+      - common/pkga-sen6x.yaml
+      - common/radar-ld2410s.yaml
+
+      # Main Config Files for Sensor Package-B and C4001 Radar
+      - common/common.yaml
+      - common/pkgb-sht4x.yaml
+      - common/pkgb-scd4x.yaml
+      - common/pkgb-sgp4x.yaml
+      - common/radar-c4001.yaml
+
+      # Main Config Files for Sensor Package-B and LD2410 Radar
+      - common/common.yaml
+      - common/pkgb-sht4x.yaml
+      - common/pkgb-scd4x.yaml
+      - common/pkgb-sgp4x.yaml
+      - common/radar-ld2410.yaml
+
+      # Main Config Files for Sensor Package-B and LD2450 Radar
+      - common/common.yaml
+      - common/pkgb-sht4x.yaml
+      - common/pkgb-scd4x.yaml
+      - common/pkgb-sgp4x.yaml
+      - common/radar-ld2450.yaml
+
+      # Main Config Files for Sensor Package-B and LD2410S Radar, Warning: Rev-B only!
+      - common/common.yaml
+      - common/pkgb-sht4x.yaml
+      - common/pkgb-scd4x.yaml
+      - common/pkgb-sgp4x.yaml
+      - common/radar-ld2410s.yaml
+```
+
+The additional Sensors and Features packages can mostly be included or not based on whether or not the sensors are populated on the board.
+
+As an example, if you enable SCD4X pressure compensation but don't have a SCD4X sensor installed it's not going to work.
+
+## Settings
+
+```yaml
+substitutions:
+  name: "office-sensor"
+  friendly_name: "Office Sensor"
+
+  # Settings
+  voice_name: "adam-male"
+  # Status LED Configuration
+  status_nightlight_brightness: "1.0"
+  status_day_brightness: "0.5"
+  status_night_brightness: "0.20"
+  status_daytime_lux: "12.0"
+  status_nighttime_lux: "7.0"
+  presence_ha_entity: "binary_sensor.unknown_room_occupancy"
+```
+
+These are base settings available for any configuration.
+
++ **name** (string): The standard ESPHome hostname. Alphanumeric and dash only. This must be defined in main config file.
++ **friendly_name** (string): The standard ESPHome friendly name. This must be defined in main config file.
++ **voice_name** (string): Spoken announcements are made with this voice. One of: `adam-male`,
+  `eryn-informative-female`, `katie-x-female`, `lucy-fresh-female`, `northern-terry-male` or `river-female`
++ **status_nightlight_brightness** (float): This is the brightness level of the nightlight when enabled. Range is `0` to `1.0` where `1.0` means 100% brightness. Default is `1.0`.
++ **status_night_brightness** (float): How bright is the Status LED during at night. Range is `0` to `1.0` where `1.0` means 100% brightness. Default is `0.15`.
++ **status_daytime_lux** (float): The light level (lux) at which the Status LED will switch to daytime mode. Default is `10.0`.
++ **status_nighttime_lux** (float): The light level (lux) at which the Status LED will switch to nighttime mode. Default is `3.0`.
+
+## Carbon Monoxide(CO) Configuration
+
+```yaml
+packages:
+  # Carbon Dioxide (CO) - Figaro TGS5141 sensor
+  co: github://mikelawrence/esphome-indoor-multi-sensor-config/common/add-co.yaml@main
+```
+
+If you have included this package the CO sensor is enabled. There are no substitutions to edit.
+
+## Energy Usage Configuration
+
+```yaml
+packages:
+  # Energy Usage - INA2XX sensor to measure Voltage, Power and Energy Usage
+  ina2xx: github://mikelawrence/esphome-indoor-multi-sensor-config/common/add-ina2xx-rev-b.yaml@main
+```
+
+If you have included this package the Energy Usage Sensor is enabled. Voltage, Power and Energy Usage will be reported as sensors. There are no substitutions to edit.
+
+## Light Sensor Configuration
+
+```yaml
+packages:
+  # Light Level - TSL2591 sensor
+  tsl2591: github://mikelawrence/esphome-indoor-multi-sensor-config/common/add-tsl2591.yaml@main
+```
+
+If you have included this package the TSL2591 Light Level Sensor is enabled. Light Level in lux will be reported as a sensor. There are no substitutions to edit.
+
+## Barometric Pressure Sensor Configuration
+
+```yaml
+packages:
+  # Barometric Pressure - BMP581 sensor
+  bmp581: github://mikelawrence/esphome-indoor-multi-sensor-config/common/add-bmp581.yaml@main
+```
+
+If you have included this package the BMP581 Barometric Pressure Sensor is enabled. The sensor reports absolute pressure. There are no substitutions to edit.
+
+## Microphone Configuration
+
+```yaml
+packages:
+  # Microphone - Adds Sound Level meter
+  mic: github://mikelawrence/esphome-indoor-multi-sensor-config/common/add-microphone.yaml@main
+```
+
+If you have included this package the ICS-43434 MEMS microphone is enabled. The microphone measures sound levels and reports to levels a one minute average and one minute peak. There are no substitutions to edit.
+
+## Automatically controlled Vent Configuration
+
+```yaml
+packages:
+  # Automatic Vent - Use humidity and CO₂ to control a bathroom vent
+  auto-vent: github://mikelawrence/esphome-indoor-multi-sensor-config/common/feat-auto-vent.yaml@main
+```
+
+If you have included this package the Automatic Vent control is enabled and there are substitutions you need to edit.
+
+```yaml
+substitutions:
+  # Automatically controlled Vent
+  vent_use_humidity: "true"
+  vent_use_co2: "false"
+  vent_min_on_time: "15"
+  vent_hum_on_trigger: "10.0"
+  vent_hum_off_trigger: "2.5"
+  vent_co2_on_trigger: "1500"
+  vent_co2_off_trigger: "1400"
+```
+
++ **vent_use_humidity** (bool): Enable humidity based control of the vent by setting this to `true`. Default is `true`.
++ **vent_use_co2** (bool): Enable CO₂ based control of the vent by setting this to `true`. Default is `false`
++ **vent_min_on_time** (integer): This is the minimum on time for a vent for manual mode and how long the vent will stay on after the humidity or CO₂ returns to normal. Default is `15`.
++ **vent_hum_on_trigger** (integer): This is the humidity level (%) rise from baseline that will turn on the vent. Baseline here is a fast exponential average (15 minutes). Showers usually have a sharp rise in humidity when first starting so a value of 10% rise in a few minutes is definitely a shower starting. Default is `10.0`.
++ **vent_hum_off_trigger** (integer): This is the humidity level (%) from baseline that will turn off the vent. Baseline here is a slow exponential average (6ish hours). You want this number slightly above zero because sometimes the humidity level doesn't go back to where it was before a shower occurred quick enough. And even though the baseline average will eventually get there and cut off the vent it will have been on for hours. Default is `2.5`.
++ **vent_co2_on_trigger** (integer): This is the CO₂ level that will cause the vent to turn on. Make 100-200 higher than `vent_co2_off_trigger` to give the vent a bit of hysteresis. Default is `1500`.
++ **vent_co2_off_trigger** (integer): This is the CO₂ level that will cause the vent to turn off. Default is `1400`.
+
+## Smoke Alarm Configuration
+
+```yaml
+packages:
+  # Smoke Alarm - Use PM, CO and CO₂ for smoke alarm functionality
+  smoke-alarm: github://mikelawrence/esphome-indoor-multi-sensor-config/common/feat-smoke-alarm.yaml@main
+```
+
+If you have included this package the you can use multiple sensors to approximate a smoke detector. This is not a certified smoke detector and my not work at all. You have been warned!
+
+[back](./)

--- a/static/index.md
+++ b/static/index.md
@@ -28,4 +28,6 @@ Use the buttons below to install pre-built firmware directly to your Rev-B hardw
 
 # Next steps
 
-Right now Home Assistant is the only destination for this sensor. Click [here](./home-assistant.html) to learn what's available in Home Assistant.
+Right now Home Assistant is the only destination for this sensor. Click [Home Assistant configuration page](./home-assistant.html) to learn what's available in Home Assistant.
+
+So you have taken control what's next? Go to the [ESPHome configuration page](./configuration.html) to learn just how much trouble you can get into with this sensor!


### PR DESCRIPTION
Once you Take Over a sensor substitutions in the configuration make sense. This PR adds back all available substitutions. The GitHub Pages have also be updated with documentation reqarding substitutions.