### PR TITLE
LD2450 Presence update quick

### DIFF
--- a/common/radar-ld2450.yaml
+++ b/common/radar-ld2450.yaml
@@ -218,7 +218,10 @@ script:
         if(!id(presence_mmwave).has_state() || id(presence_mmwave).state != total_tgt_count > 0)
           id(presence_mmwave).publish_state(total_tgt_count > 0);
 
-        if(time - last_update_time > static_cast<uint64_t>(id(update_rate).state * 1000.0))
+        // Only update if the update rate time has elapsed or target count went from 0 to 1 or more targets
+        //   this prevents unnecessary updates when targets are present and moving around
+        if ((time - last_update_time > static_cast<uint64_t>(id(update_rate).state * 1000.0)) ||
+            (id(tgt_cnt).state == 0 && total_tgt_count > 0))
         {
           // publish target values
           for(uint8_t tgt = 0; tgt < 3; tgt++)


### PR DESCRIPTION
Speeds up initial presence detection by bypassing the Presence Timeout when the first target is detected.